### PR TITLE
chore: revert part of 5e3eebf2 for useField changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ useWatch({
   defaultValue: 'data', // this value will only show on the inital render
 });
 ```
+- TS: name changed from `ValidationRules` to `RegisterOptions` due to valueAs functionality included as `register` function.
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form",
   "description": "Performant, flexible and extensible forms library for React Hooks",
-  "version": "6.12.1",
+  "version": "6.12.2-beta.1",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "umd:main": "dist/index.umd.production.min.js",

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -31,7 +31,7 @@ export default async <TFieldValues extends FieldValues>(
   validateAllFieldCriteria: boolean,
   {
     ref,
-    ref: { type, value },
+    ref: { value },
     options,
     required,
     maxLength,
@@ -99,13 +99,13 @@ export default async <TFieldValues extends FieldValues>(
     }
   }
 
-  if (!isNullOrUndefined(min) || !isNullOrUndefined(max)) {
+  if ((!isNullOrUndefined(min) || !isNullOrUndefined(max)) && value !== '') {
     let exceedMax;
     let exceedMin;
     const maxOutput = getValueAndMessage(max);
     const minOutput = getValueAndMessage(min);
 
-    if (type === 'number' || (!type && !isNaN(value))) {
+    if (!isNaN(value)) {
       const valueNumber =
         (ref as HTMLInputElement).valueAsNumber || parseFloat(value);
       if (!isNullOrUndefined(maxOutput.value)) {

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -147,7 +147,7 @@ export function useField<
           rules,
         );
 
-        shouldUpdateValue = !get(defaultValuesRef.current, name);
+        shouldUpdateValue = isUndefined(get(defaultValuesRef.current, name));
       }
 
       shouldUpdateValue &&
@@ -178,7 +178,7 @@ export function useField<
   }, [registerField]);
 
   React.useEffect(() => {
-    isNotFieldArray && !fieldsRef.current[name] && registerField(true);
+    !fieldsRef.current[name] && registerField(true);
   });
 
   const onBlur = React.useCallback(() => {

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -147,7 +147,7 @@ export function useField<
           rules,
         );
 
-        shouldUpdateValue = isUndefined(get(defaultValuesRef.current, name));
+        shouldUpdateValue = !get(defaultValuesRef.current, name);
       }
 
       shouldUpdateValue &&
@@ -178,7 +178,7 @@ export function useField<
   }, [registerField]);
 
   React.useEffect(() => {
-    !fieldsRef.current[name] && registerField(true);
+    isNotFieldArray && !fieldsRef.current[name] && registerField(true);
   });
 
   const onBlur = React.useCallback(() => {

--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -2510,6 +2510,82 @@ describe('useFieldArray', () => {
       expect(result.current.formState.dirtyFields).toEqual({});
     });
 
+    it('should remove Controller by index without error', () => {
+      const Component = () => {
+        const { control, handleSubmit } = useForm({
+          defaultValues: {
+            test: [],
+          },
+        });
+        const { fields, append, remove } = useFieldArray({
+          control,
+          name: 'test',
+        });
+
+        return (
+          <form onSubmit={handleSubmit(() => {})}>
+            <ul>
+              {fields.map((item, index) => {
+                return (
+                  <li key={item.id}>
+                    <Controller
+                      as={<input />}
+                      name={`test[${index}].firstName`}
+                      control={control}
+                      defaultValue={item.firstName} // make sure to set up defaultValue
+                    />
+                    <button type="button" onClick={() => remove(index)}>
+                      delete
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+            <section>
+              <button
+                type="button"
+                onClick={() => {
+                  append({ firstName: 'appendBill' });
+                }}
+              >
+                append
+              </button>
+            </section>
+
+            <input type="submit" />
+          </form>
+        );
+      };
+
+      render(<Component />);
+
+      actComponent(() => {
+        fireEvent.click(screen.getByRole('button', { name: 'append' }));
+      });
+      actComponent(() => {
+        fireEvent.click(screen.getByRole('button', { name: 'append' }));
+      });
+      actComponent(() => {
+        fireEvent.click(screen.getByRole('button', { name: 'append' }));
+      });
+      actComponent(() => {
+        fireEvent.click(screen.getByRole('button', { name: 'append' }));
+      });
+
+      actComponent(() => {
+        fireEvent.click(screen.getAllByRole('button', { name: 'delete' })[1]);
+      });
+      actComponent(() => {
+        fireEvent.click(screen.getAllByRole('button', { name: 'delete' })[1]);
+      });
+      actComponent(() => {
+        fireEvent.click(screen.getAllByRole('button', { name: 'delete' })[1]);
+      });
+      actComponent(() => {
+        fireEvent.click(screen.getAllByRole('button', { name: 'delete' })[0]);
+      });
+    });
+
     it("should not reset Controller's value during remove when Field Array name is already registered", () => {
       function Component() {
         const { control, handleSubmit } = useForm({

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -488,6 +488,10 @@ export const useFieldArray = <
     }
 
     return () => {
+      if (process.env.NODE_ENV !== 'production') {
+        return;
+      }
+
       resetFields();
       delete resetFunctions[name];
       unset(fieldArrayValuesRef, name);

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -422,7 +422,7 @@ export function useForm<
         return result.every(Boolean);
       }
 
-      return await executeValidation(fields, readFormStateRef.current.isValid);
+      return await executeValidation(fields);
     },
     [executeSchemaOrResolverValidation, executeValidation],
   );
@@ -810,9 +810,9 @@ export function useForm<
             [],
           );
           fieldValues =
+            !fieldArrayValue.length ||
             fieldArrayValue.length !==
-              compact(get(fieldValues, fieldNames, [])).length ||
-            !fieldArrayValue.length
+              compact(get(fieldValues, fieldNames, [])).length
               ? fieldArrayValuesRef.current
               : fieldValues;
         }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -35,6 +35,7 @@ import isMultipleSelect from './utils/isMultipleSelect';
 import compact from './utils/compact';
 import isNullOrUndefined from './utils/isNullOrUndefined';
 import isRadioOrCheckboxFunction from './utils/isRadioOrCheckbox';
+import isWeb from './utils/isWeb';
 import isHTMLElement from './utils/isHTMLElement';
 import { EVENTS, UNDEFINED, VALIDATION_MODE } from './constants';
 import {
@@ -74,10 +75,6 @@ import {
 } from './types';
 
 const isWindowUndefined = typeof window === UNDEFINED;
-const isWeb =
-  typeof document !== UNDEFINED &&
-  !isWindowUndefined &&
-  !isUndefined(HTMLElement);
 const isProxyEnabled = isWeb ? 'Proxy' in window : typeof Proxy !== UNDEFINED;
 
 export function useForm<
@@ -159,7 +156,7 @@ export function useForm<
   shallowFieldsStateRef.current = shouldUnregister
     ? {}
     : isEmptyObject(shallowFieldsStateRef.current)
-    ? cloneObject(defaultValues, isWeb)
+    ? cloneObject(defaultValues)
     : shallowFieldsStateRef.current;
 
   const updateFormState = React.useCallback(
@@ -639,7 +636,7 @@ export function useForm<
 
   function setFieldArrayDefaultValues<T extends FieldValues>(data: T): T {
     if (!shouldUnregister) {
-      let copy = cloneObject(data, isWeb);
+      let copy = cloneObject(data);
 
       for (const value of fieldArrayNamesRef.current) {
         if (isKey(value) && !copy[value]) {
@@ -682,7 +679,7 @@ export function useForm<
     return setFieldArrayDefaultValues(
       getFieldsValues(
         fieldsRef,
-        cloneObject(shallowFieldsStateRef.current, isWeb),
+        cloneObject(shallowFieldsStateRef.current),
         shouldUnregister,
       ),
     );
@@ -799,7 +796,7 @@ export function useForm<
         : watchFieldsRef.current;
       let fieldValues = getFieldsValues<TFieldValues>(
         fieldsRef,
-        cloneObject(shallowFieldsStateRef.current, isWeb),
+        cloneObject(shallowFieldsStateRef.current),
         shouldUnregister,
         false,
         fieldNames,
@@ -1089,7 +1086,7 @@ export function useForm<
       let fieldValues = setFieldArrayDefaultValues(
         getFieldsValues(
           fieldsRef,
-          cloneObject(shallowFieldsStateRef.current, isWeb),
+          cloneObject(shallowFieldsStateRef.current),
           shouldUnregister,
           true,
         ),
@@ -1221,10 +1218,7 @@ export function useForm<
     }
 
     fieldsRef.current = {};
-    defaultValuesRef.current = cloneObject(
-      values || defaultValuesRef.current,
-      isWeb,
-    );
+    defaultValuesRef.current = cloneObject(values || defaultValuesRef.current);
     values && renderWatchedInputs('');
 
     Object.values(resetFieldArrayFunctionRef.current).forEach(
@@ -1233,7 +1227,7 @@ export function useForm<
 
     shallowFieldsStateRef.current = shouldUnregister
       ? {}
-      : cloneObject(values, isWeb) || {};
+      : cloneObject(values) || {};
 
     resetRefs(omitResetState);
   };

--- a/src/utils/cloneObject.test.ts
+++ b/src/utils/cloneObject.test.ts
@@ -35,8 +35,8 @@ describe('clone', () => {
       ]),
     };
 
-    const copy = cloneObject(data, true);
-    expect(cloneObject(data, true)).toEqual(copy);
+    const copy = cloneObject(data);
+    expect(cloneObject(data)).toEqual(copy);
 
     // @ts-ignore
     copy.test.what = '1243';

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -1,9 +1,7 @@
 import isPrimitive from './isPrimitive';
+import isWeb from './isWeb';
 
-export default function cloneObject<T extends unknown>(
-  data: T,
-  isWeb = true,
-): T {
+export default function cloneObject<T extends unknown>(data: T): T {
   let copy: any;
 
   if (isPrimitive(data) || (isWeb && data instanceof File)) {
@@ -26,7 +24,7 @@ export default function cloneObject<T extends unknown>(
   if (data instanceof Map) {
     copy = new Map();
     for (const key of data.keys()) {
-      copy.set(key, cloneObject(data.get(key), isWeb));
+      copy.set(key, cloneObject(data.get(key)));
     }
     return copy;
   }
@@ -34,7 +32,7 @@ export default function cloneObject<T extends unknown>(
   copy = Array.isArray(data) ? [] : {};
 
   for (const key in data) {
-    copy[key] = cloneObject(data[key], isWeb);
+    copy[key] = cloneObject(data[key]);
   }
 
   return copy;

--- a/src/utils/isWeb.ts
+++ b/src/utils/isWeb.ts
@@ -1,0 +1,3 @@
+import { UNDEFINED } from '../constants';
+
+export default typeof window !== UNDEFINED && typeof document !== UNDEFINED;


### PR DESCRIPTION
Part of PR https://github.com/react-hook-form/react-hook-form/pull/3583 for the useField.ts tightened the should update to only include `isUndefined`.

Revert this one change back to see if it fixes the null allowance.